### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: Mozilla
+IndentWidth: 4
+---


### PR DESCRIPTION
Adds `.clang-format` for auto formatting based on the style we decided upon.

Uses the `Mozilla` style as a base, which can be found here: https://firefox-source-docs.mozilla.org/code-quality/coding-style/index.html The only change that was needed was to update to 4-space indents.

