### PR TITLE
Get SPI working

### DIFF
--- a/client/app/include/spiExample.h
+++ b/client/app/include/spiExample.h
@@ -1,0 +1,69 @@
+#include <fcntl.h>
+#include <linux/spi/spidev.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#define SPI_DEV_BUS1_CS0 "/dev/spidev1.0"
+
+#define SPI_MODE_DEFAULT 0
+#define SPEED_HZ_DEFAULT 4000000
+
+int
+SPI_initPort(char* spiDevice)
+{
+    // Open Device
+    int spiFileDesc = open(spiDevice, O_RDWR);
+    if (spiFileDesc < 0) {
+        printf("Error: Can't open device %s\n", spiDevice);
+        exit(1);
+    }
+    // Set port parameters
+    // Set SPI mode: Necessary
+    int spiMode = SPI_MODE_DEFAULT;
+    int errorCheck = ioctl(spiFileDesc, SPI_IOC_WR_MODE, &spiMode);
+    if (errorCheck < 0) {
+        printf("Error: Set SPI mode failed\n");
+        exit(1);
+    }
+    // Set Max Speed (Hz): Optional
+    int speedHz = SPEED_HZ_DEFAULT;
+    errorCheck = ioctl(spiFileDesc, SPI_IOC_WR_MAX_SPEED_HZ, &speedHz);
+    if (errorCheck < 0) {
+        printf("Error: Set max speed failed\n");
+        exit(1);
+    }
+    return spiFileDesc;
+}
+
+int
+SPI_example(void)
+{
+    int spifd = SPI_initPort(SPI_DEV_BUS1_CS0);
+
+    uint8_t txBuf[] = { (0x37 << 1) | 0x80, 0 };
+    uint8_t rxBuf[] = { 0, 0 };
+
+    struct spi_ioc_transfer spiTransaction;
+    memset(&spiTransaction, 0, sizeof(struct spi_ioc_transfer));
+
+    spiTransaction.tx_buf = (unsigned long)&txBuf;
+    spiTransaction.rx_buf = (unsigned long)&rxBuf;
+    spiTransaction.len = 2;
+
+    printf("Reading from version register with formatted address %x...\n",
+           txBuf[0]);
+    printf("We expect the version to be either 0x91 or 0x92\n");
+    printf(".....\n");
+
+    int status = ioctl(spifd, SPI_IOC_MESSAGE(1), &spiTransaction);
+    if (status < 0) {
+        printf("Error: SPI Transfer failed\n");
+        perror("SPI error");
+    } else {
+        printf("Received version: %x\n", rxBuf[1]);
+    }
+    return 0;
+}

--- a/client/app/src/main.c
+++ b/client/app/src/main.c
@@ -1,18 +1,12 @@
 // Main program to build the application
 // Has main(); does initialization and cleanup and perhaps some basic logic.
-
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "tcpExample.h"
-#include "ultrasonicExample.h"
+#include "spiExample.h"
 
 int
 main(int argc, char** argv)
 {
     (void)argc;
     (void)argv;
-    // tcpExample(argc, argv);
-    ultrasonicExample();
-    return 0;
+
+    return SPI_example();
 }

--- a/client/env/82-spi-noroot.rules
+++ b/client/env/82-spi-noroot.rules
@@ -1,0 +1,1 @@
+KERNEL=="spidev*", GROUP="spiusr", MODE="0660"

--- a/client/env/uEnv.txt
+++ b/client/env/uEnv.txt
@@ -1,0 +1,57 @@
+#Docs: http://elinux.org/Beagleboard:U-boot_partitioning_layout_2.0
+
+uname_r=5.10.168-ti-r75
+#uuid=
+#dtb=
+
+###U-Boot Overlays###
+###Documentation: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
+###Master Enable
+enable_uboot_overlays=1
+###
+###Overide capes with eeprom
+#uboot_overlay_addr0=<file0>.dtbo
+#uboot_overlay_addr1=<file1>.dtbo
+#uboot_overlay_addr2=<file2>.dtbo
+#uboot_overlay_addr3=<file3>.dtbo
+###
+###Additional custom capes
+uboot_overlay_addr4=/lib/firmware/BB-SPIDEV1-00A0.dtbo
+#uboot_overlay_addr4=/lib/firmware/BB-BONE-AUDI-02-00A0.dtbo
+#uboot_overlay_addr6=<file6>.dtbo
+#uboot_overlay_addr7=<file7>.dtbo
+###
+###Custom Cape
+#dtb_overlay=<file8>.dtbo
+###
+###Disable auto loading of virtual capes (emmc/video/wireless/adc)
+#disable_uboot_overlay_emmc=1
+disable_uboot_overlay_video=1
+disable_uboot_overlay_audio=1
+#disable_uboot_overlay_wireless=1
+#disable_uboot_overlay_adc=1
+###
+###Cape Universal Enable
+enable_uboot_cape_universal=1
+###
+###Debug: disable uboot autoload of Cape
+#disable_uboot_overlay_addr0=1
+#disable_uboot_overlay_addr1=1
+#disable_uboot_overlay_addr2=1
+#disable_uboot_overlay_addr3=1
+###
+###U-Boot fdt tweaks... (60000 = 384KB)
+#uboot_fdt_buffer=0x60000
+###U-Boot Overlays###
+
+console=ttyS0,115200n8
+cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 quiet
+
+#In the event of edid real failures, uncomment this next line:
+#cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 quiet video=HDMI-A-1:1024x768@60e
+
+#Use an overlayfs on top of a read-only root filesystem:
+#cmdline=coherent_pool=1M net.ifnames=0 lpj=1990656 rng_core.default_quality=100 quiet overlayroot=tmpfs
+
+##enable Generic eMMC Flasher:
+#cmdline=init=/usr/sbin/init-beagle-flasher


### PR DESCRIPTION
# SPI interface to the RC522 module

This PR adds an example program to test that SPI communication with the RC522 module works and includes the necessary configuration to get it running.

## Steps to configure the board

1. **Set up device tree overlay:** See `client/env/uEnv.txt`. The configuration is:
    - Disable hdmi and audio by uncommenting `disable_uboot_overlay_video=1` and `disable_uboot_overlay_audio=1`
    - Ensure the DTO for the audio is **not** loaded (`/lib/firmware/BB-BONE-AUDI-02-00A0.dto`)
    - Load the overlay for spidev bus 1 (`/lib/firmware/BB-SPIDEV1-00A0.dto`)
2. **Add the udev rule to enable user access:** This lets us use the spidev driver interface without root access:
    - Copy `client/env/82-spi-noroot.rules` to `/etc/udev/rules.d` on the BBG.
    - Add the `spiusr` group with `sudo groupadd spiusr`
    - Add the `debian` user to the `spiusr` group with `sudo gpasswd -a debian spiusr`
3. **Restart the board** for the changes to take effect. They will all persist across reboots.
4. **Confirm the changes:**
    - Verify that the `spidev` driver was loaded by checking that `/dev/spidev1.0` exists and belongs to the `spiusr` group with `ls -al /dev/spidev1.0`
    - Verify that the pins are allocated properly by running `show-pins`. Pins P9 28-31 should show allocation to spi in the rightmost 3 columns of the output. This is done by the DTO; you should **not** have to run `config-pin`.

## Running the example

Wire the module to the board as follows:

| BBG pin | Module pin|
|-------------|-------|
| P9.28 | SDA |
| P9.29 | MISO |
| P9.30 | MOSI |
| P9.31 | SCK |
| P9.2 | GND |
| P9.3 | 3V3 |

Build and run the client on the BBG. You should **not** require root access. The output should show that the value `92` was read from the register `ee`.