### PR TITLE
Add mood mapping

### DIFF
--- a/client/app/include/singer.h
+++ b/client/app/include/singer.h
@@ -31,9 +31,9 @@ typedef enum
 
 typedef struct
 {
-    atomic_uint emotion; // TODO: I'm anticipating that both segDisplay and
+    atomic_uint emotion; // I'm anticipating that both segDisplay and
                          // melodygen might want to access this, so it's atomic.
-    float magnitude; // Magnitude, however, will only be accessed by melodygen.
+    float magnitude;
 } Mood;
 
 /** Initialize the system. */

--- a/client/app/src/app.c
+++ b/client/app/src/app.c
@@ -86,16 +86,11 @@ App_runApp(char* serverIp)
             }
             // If not on tag and player not running, do melody generation
             else {
-                // TODO @ Spencer: This is how I personally envisioned tying in
-                // the mood. Emotion would affect Major/Minor key, while
-                // magnitude would affect all the other params. I am ill
-                // equipped to write the generateParams function, though.
-
-                // mood = a struct that contains (1) emotion, (2) magnitude
-                // Mood* mood = Singer_getMood();
-
-                // MelodyGenParams params = Melody_generateParams(mood);
-                // Melody_generateToSequencer(params);
+                Mood* mood = Singer_getMood();
+                Melody_playMelody(
+                  mood); // TODO: Do we have to make it so that a generated
+                         // melody finishes playing before we call the function
+                         // to play another melody? If so, how?
             }
         }
     }

--- a/client/app/src/singer.c
+++ b/client/app/src/singer.c
@@ -132,12 +132,8 @@ _updateMood(Sensory_State* state)
             break;
     }
 
-    // TODO: Not sure about what to set the magnitude to. Should NEUTRAL have
-    // differing intensities, or is NEUTRAL just a flat thing?
     if (withinHyperbola) {
         mood.emotion = EMOTION_NEUTRAL;
-        mood.magnitude = 0.1;
-        return;
     }
 
     // With that, we have finished determining the emotion. Now, the magnitude.

--- a/client/das/CMakeLists.txt
+++ b/client/das/CMakeLists.txt
@@ -8,5 +8,6 @@ file(GLOB MY_SOURCES "src/*.c")
 add_library(das STATIC ${MY_SOURCES})
 
 target_include_directories(das PUBLIC include
-                                      "${CMAKE_SOURCE_DIR}/common/include")
+                                      "${CMAKE_SOURCE_DIR}/common/include"
+                                      "${CMAKE_SOURCE_DIR}/app/include") # for Mood
 target_link_libraries(das m)

--- a/client/das/include/das/melodygen.h
+++ b/client/das/include/das/melodygen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "das/fm.h"
+#include "singer.h"
 
 /** A fast bpm. */
 #define TEMPO_FAST 180
@@ -116,8 +117,54 @@ static const Chord minorProgressions[][4] = { { vi, ii, Va6, vi },
                                               { vi6, I7, IV7, Va6 },
                                               { ii, IV42, Va6, vi } };
 
+/** Params that serve as a baseline for a mood, and can be altered further by
+ * multiplying mood magnitude. */
+
+// TODO: Adjust these params to fit your vision. I did this roughly.
+
+// faster tempo, jumpy melody, major key
+static const MelodyGenParams happyParams = { .tempo = TEMPO_FAST,
+                                             .key = KEY_MINOR,
+                                             .jumpChance = 0.7,
+                                             .noteDensity = 0.7,
+                                             .upDownTendency = 0.6,
+                                             .stoccatoLegatoTendency = 0.7 };
+
+// slower tempo, longer notes
+static const MelodyGenParams sadParams = { .tempo = TEMPO_SLOW,
+                                           .key = KEY_MINOR,
+                                           .jumpChance = 0.2,
+                                           .noteDensity = 0.3,
+                                           .upDownTendency = 0.4,
+                                           .stoccatoLegatoTendency = 0.1 };
+
+// medium tempo, ascending melody
+static const MelodyGenParams angryParams = { .tempo = TEMPO_MEDIUM,
+                                             .key = KEY_MINOR,
+                                             .jumpChance = 0.3,
+                                             .noteDensity = 1.0,
+                                             .upDownTendency = 1.0,
+                                             .stoccatoLegatoTendency = 0.5 };
+
+// glitchy, random, amelodic sounds
+static const MelodyGenParams overstimulatedParams = { .tempo = TEMPO_FAST,
+                                                      .key = KEY_MINOR,
+                                                      .jumpChance = 0.9,
+                                                      .noteDensity = 0.1,
+                                                      .upDownTendency = 0.5,
+                                                      .stoccatoLegatoTendency =
+                                                        0.5 };
+
+// sparse drone/boops
+static const MelodyGenParams neutralParams = { .tempo = TEMPO_MEDIUM,
+                                               .key = KEY_MAJOR,
+                                               .jumpChance = 0.5,
+                                               .noteDensity = 0.3,
+                                               .upDownTendency = 0.5,
+                                               .stoccatoLegatoTendency = 0.5 };
+
 /**
- * Generates a melody to the sequencer according to the given params.
+ * Generates a melody according to the mood.
  */
 void
-Melody_generateToSequencer(const MelodyGenParams* params);
+Melody_playMelody(const Mood* mood);

--- a/client/das/src/melodygen.c
+++ b/client/das/src/melodygen.c
@@ -164,8 +164,8 @@ _getPassingTone(const Note from, const int direction)
     return from + _noteSignedRingDistance(stripped, majorScale[noteIdx]);
 }
 
-void
-Melody_generateToSequencer(const MelodyGenParams* params)
+static void
+_generateToSequencer(const MelodyGenParams* params)
 {
     Sequencer_setBpm(params->tempo);
 
@@ -236,4 +236,42 @@ Melody_generateToSequencer(const MelodyGenParams* params)
         }
         _lastNotePlayed = currentNote;
     }
+}
+
+void
+Melody_playMelody(const Mood* mood)
+{
+    MelodyGenParams params;
+
+    // Retrieve the baseline params for any mood. These are defined in
+    // melodygen.h.
+    switch (mood->emotion) {
+        case EMOTION_HAPPY:
+            params = happyParams;
+            break;
+        case EMOTION_SAD:
+            params = sadParams;
+            break;
+        case EMOTION_ANGRY:
+            params = angryParams;
+            break;
+        case EMOTION_OVERSTIMULATED:
+            params = overstimulatedParams;
+            break;
+        case EMOTION_NEUTRAL:
+            params = neutralParams;
+            break;
+        default:
+            params = neutralParams;
+            break;
+    }
+
+    // Factor in the mood magnitude [0.0 - 1.0]
+    params.jumpChance *= mood->magnitude;
+    params.noteDensity *= mood->magnitude;
+    params.upDownTendency *= mood->magnitude;
+    params.stoccatoLegatoTendency *= mood->magnitude;
+
+    // Pass the final params to the melody generating function
+    _generateToSequencer(&params);
 }


### PR DESCRIPTION
**IMPORTANT**: Please Ctrl+F TODOs for questions I don't have the answer to.

-- Summary --

I created a Mood struct that has two fields: emotion (ex. HAPPY), and magnitude.

Using our whiteboard graph as a reference...

-Emotion is determined by the quadrant that the coords lie in.
-Magnitude is determined by the distance from the origin.

I implemented the "NEUTRAL ZONE" via hyperbolae.

Any module can call Singer_getMood() to get a pointer to the Mood struct. The way I envision it, I believe both app.c and SegDisplay.c will call Singer_getMood().