### PR TITLE
Add segDisplay eyes, config file for Zen Cape Red and Green

### DIFF
--- a/client/app/include/eyesExample.h
+++ b/client/app/include/eyesExample.h
@@ -1,0 +1,27 @@
+#include "com/timeutils.h"
+#include "hal/i2c.h"
+#include "hal/segDisplay.h"
+
+#define MOOD_DURATION_ms 5000
+
+// Displays all 6 moods in sequence, each mood lasting 5 seconds.
+// To use, clear main.c and replace with eyesExample().
+void
+eyesExample(void)
+{
+
+    srand(time(NULL));
+
+    SegDisplay_init();
+
+    for (int i = 0; i < 6; i++) {
+        int mood = i;
+        printf("Current mood: %d\n", mood);
+
+        long long currTime = Timeutils_getTimeInMs();
+
+        while (currTime + MOOD_DURATION_ms > Timeutils_getTimeInMs()) {
+            SegDisplay_displayEmotion(mood);
+        }
+    }
+}

--- a/client/common/include/com/config.h
+++ b/client/common/include/com/config.h
@@ -1,0 +1,73 @@
+#pragma once
+
+/* ******************************************
+ * Uncomment the following for Zen Cape RED *
+ * ****************************************** */
+
+// ///////////////// accel.c ////////////////////////
+// #define ACCEL_ADDR 0x18
+// #define ACCEL_ACTIVE_MODE (1 << 5) | 0x7
+// #define ACCEL_CTRL_REG1 0x20
+// #define ACCEL_DATA_READ 0x28 + 0x80
+// #define ACCEL_NUM_BYTES_TO_READ 6
+// #define ACCEL_INDEX_ADJUST 0
+
+// //////////////// segDisplay.c  /////////////////////
+// #define SEGDISPLAY_I2C_ADDRESS 0x20
+// #define SEGDISPLAY_DIRA_REG 0x02
+// #define SEGDISPLAY_DIRB_REG 0x03
+// #define SEGDISPLAY_OUTA_REG 0x00
+// #define SEGDISPLAY_OUTB_REG 0x01
+
+// static const uint8_t EYES_HAPPY[4] = { 0x83, 0x48, 0x83, 0x48 };
+// static const uint8_t EYES_SAD[4] = { 0x06, 0x10, 0x10, 0x18 };
+// static const uint8_t EYES_ANGRY[4] = { 0x10, 0x02, 0x04, 0x02 };
+// static const uint8_t EYES_OVERSTIMULATED[4] = { 0x14, 0x05, 0x14, 0x05 };
+// static const uint8_t EYES_NEUTRAL[4] = { 0x21, 0x02, 0x01, 0x82 };
+// static const uint8_t EYES_SINGING[4] = { 0x81, 0x50, 0x81, 0x50 };
+
+// static const uint8_t BLINK_HAPPY[4] = { 0x01, 0x10, 0x01, 0x10 };
+// static const uint8_t BLINK_SAD[4] = { 0x06, 0x00, 0x10, 0x08 };
+// static const uint8_t BLINK_ANGRY[4] = { 0x00, 0x14, 0x00, 0x11 };
+// static const uint8_t BLINK_OVERSTIMULATED[4] = { 0x02, 0x08, 0x02, 0x08 };
+// static const uint8_t BLINK_NEUTRAL[4] = { 0x21, 0x10, 0x01, 0x90 };
+// static const uint8_t BLINK_SINGING[4] = { 0x81, 0x50, 0x81, 0x50 };
+
+/* ********************************************
+ * Uncomment the following for Zen Cape GREEN *
+ * ********************************************/
+
+///////////////// accel.c ////////////////////////
+#define ACCEL_ADDR 0x1C
+#define ACCEL_ACTIVE_MODE 0x01
+#define ACCEL_CTRL_REG1 0x2A
+#define ACCEL_DATA_READ 0x01
+#define ACCEL_NUM_BYTES_TO_READ 7
+#define ACCEL_INDEX_ADJUST 2
+
+//////////////// segDisplay.c  /////////////////////
+#define SEGDISPLAY_I2C_ADDRESS 0x20
+#define SEGDISPLAY_DIRA_REG 0x00
+#define SEGDISPLAY_DIRB_REG 0x01
+#define SEGDISPLAY_OUTA_REG 0x14
+#define SEGDISPLAY_OUTB_REG 0x15
+
+static const uint8_t EYES_HAPPY[4] = { 0x0C, 0x91, 0x0C, 0x91 };
+static const uint8_t EYES_SAD[4] = { 0x19, 0x20, 0x40, 0x30 };
+static const uint8_t EYES_ANGRY[4] = { 0x40, 0x04, 0x10, 0x04 };
+static const uint8_t EYES_OVERSTIMULATED[4] = { 0x50, 0x0A, 0x50, 0x0A };
+static const uint8_t EYES_NEUTRAL[4] = { 0x84, 0x04, 0x06, 0x04 };
+static const uint8_t EYES_SINGING[4] = { 0x04, 0xA1, 0x04, 0xA1 };
+
+static const uint8_t BLINK_HAPPY[4] = { 0x04, 0x20, 0x04, 0x20 };
+static const uint8_t BLINK_SAD[4] = { 0x19, 0x00, 0x40, 0x10 };
+static const uint8_t BLINK_ANGRY[4] = { 0x00, 0x28, 0x00, 0x22 };
+static const uint8_t BLINK_OVERSTIMULATED[4] = { 0x08, 0x10, 0x08, 0x10 };
+static const uint8_t BLINK_NEUTRAL[4] = { 0x84, 0x20, 0x06, 0x20 };
+static const uint8_t BLINK_SINGING[4] = { 0x04, 0xA1, 0x04, 0xA1 };
+
+/* ********************************************
+ *   Define your board's personality here...  *
+ * ********************************************/
+
+// ...

--- a/client/common/include/com/utils.h
+++ b/client/common/include/com/utils.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdlib.h>
+
+int
+Utils_getRandomIntBtwn(int min, int max);

--- a/client/common/src/utils.c
+++ b/client/common/src/utils.c
@@ -1,0 +1,17 @@
+#include "com/utils.h"
+
+int
+Utils_getRandomIntBtwn(int min, int max)
+{
+    // Reference:
+    // https://stackoverflow.com/questions/822323/how-to-generate-a-random-int-in-c
+    // Used only as a starting point.
+
+    // Example shown with max = 3000, min = 500
+    int range = max - min;                   // 2500
+    int rangeInclusive = range + 1;          // 2501
+    int randomInt = rand() % rangeInclusive; // 0    -> 2500
+    int randomIntInRange = randomInt + min;  // 500  -> 3000
+
+    return randomIntInRange;
+}

--- a/client/hal/CMakeLists.txt
+++ b/client/hal/CMakeLists.txt
@@ -7,4 +7,5 @@ file(GLOB MY_SOURCES "src/*.c")
 add_library(hal STATIC ${MY_SOURCES})
 
 target_include_directories(hal PUBLIC include
-                                      "${CMAKE_SOURCE_DIR}/common/include")
+                                      "${CMAKE_SOURCE_DIR}/common/include"
+                                      "${CMAKE_SOURCE_DIR}/app/include") # for Emotion

--- a/client/hal/include/hal/accel.h
+++ b/client/hal/include/hal/accel.h
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <sys/wait.h>
 
+#include "com/config.h"
 #include "com/fileio.h"
 
 #define ACCEL_MAX_READING 2047

--- a/client/hal/include/hal/segDisplay.h
+++ b/client/hal/include/hal/segDisplay.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "hal/i2c.h"
+
+#include "com/config.h"
+#include "com/fileio.h"
+#include "com/timeutils.h"
+#include "com/utils.h"
+
+#include "singer.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef enum
+{
+    PATTERN_LEFT_TOP = 0,
+    PATTERN_LEFT_BOT,
+    PATTERN_RIGHT_TOP,
+    PATTERN_RIGHT_BOT,
+    MAX_NUM_PATTERNS,
+} Pattern;
+
+int
+SegDisplay_init(void);
+void
+SegDisplay_shutdown(void);
+
+/*
+ * Display a pattern that represents an emotion. Internally, an emotion
+ * corresponds with two patterns - one for stationary eyes, and one for
+ * blinking. The time between blinks is randomized, as well as the duration
+ * of the blink.
+ *
+ * Each displayEmotion call displays the pattern just once.
+ */
+void
+SegDisplay_displayEmotion(Emotion emotion);

--- a/client/hal/src/accel.c
+++ b/client/hal/src/accel.c
@@ -10,17 +10,6 @@
 /** Handle to the i2c bus for communicating with the accelerometer. */
 static I2C_BusHandle i2c;
 
-/* Upon calling Accel_setCape(), ZEN_CAPE is set to 'r' for red, and 'g' for
- * green. The process to read the accel on each cape differs by a non-trivial
- * amount. Therefore, in most accel functions, we check the ZEN_CAPE with an if
- * statement, then handle both cases completely separately, as opposed to trying
- * to over-generalize the fn.
- */
-static char ZEN_CAPE = '0';
-
-#define ACCEL_STR_RED "18"
-#define ACCEL_STR_GREEN "1c"
-
 //////////////////////////////////////////
 // comment
 #if (0)
@@ -110,92 +99,21 @@ accel_get_events(accel_event_t* events)
 // end comment
 //////////////////////////////////////////
 
-/**
- * Sets the internal ZEN_CAPE variable to 'r' for red, or 'g' for
- * green. Essentially the same as fileio_pipe_command, but specifically runs the
- * command "i2cdetect -y -r 1", which displays I2C device addresses. While
- * reading through the pipe output, we check for the specific accel addresses.
- */
-static int
-Accel_setCape(void)
-{
-    // It's probably possible to do this in a more generalized sense by
-    // altering the original fileio_pipe_command, but this works for now.
-
-    // We could probably also integrate this into our config file.
-
-    FILE* pipe = popen("i2cdetect -y -r 1", "r");
-    if (!pipe) {
-        return -1;
-    }
-    char buffer[FILEIO_MED_BUFSIZE];
-    while (!feof(pipe) && !ferror(pipe)) {
-        if (fgets(buffer, sizeof(buffer), pipe) == NULL) {
-            break;
-        }
-        // Check buffer for the substring matching the accel regAddr.
-        // If found, then set.
-        if (strstr(buffer, ACCEL_STR_RED)) {
-            ZEN_CAPE = 'r';
-        } else if (strstr(buffer, ACCEL_STR_GREEN)) {
-            ZEN_CAPE = 'g';
-        }
-    }
-
-    // Explicit error handling
-    if (ZEN_CAPE != 'r' && ZEN_CAPE != 'g') {
-        ZEN_CAPE = '0';
-    }
-
-    // Get the exit code from the pipe; non-zero is an error:
-    return WEXITSTATUS(pclose(pipe));
-}
-
 int
 Accel_open(void)
 {
-    uint8_t addr;
-    uint8_t cfg;
-    uint8_t CTRL_REG1;
-
     if (I2C_openBus(I2C_BUS1, &i2c) < 0) {
         perror("i2c open");
         return -1;
     }
 
-    // The second error check should guarantee that ZEN_CAPE is either 'r' or
-    // 'g' past this point.
-    if (Accel_setCape() < 0 || ZEN_CAPE == '0') {
-        perror("accel setCape");
-        return -1;
-    }
-
-    if (ZEN_CAPE == 'r') {
-        puts("----------------------");
-        puts("You have a Red cape.");
-        puts("----------------------");
-
-        addr = 0x18;
-        cfg = (1 << 5) | 0x7;
-        CTRL_REG1 = 0x20;
-
-    } else if (ZEN_CAPE == 'g') {
-
-        puts("----------------------");
-        puts("You have a Green cape.");
-        puts("----------------------");
-
-        addr = 0x1C;
-        cfg = 0x01;
-        CTRL_REG1 = 0x2A;
-    }
-
-    if (I2C_selectDevice(&i2c, addr) < 0) {
+    if (I2C_selectDevice(&i2c, ACCEL_ADDR) < 0) {
         perror("i2c select device");
         return -1;
     }
 
-    if (I2C_write(&i2c, CTRL_REG1, &cfg, 1) < 0) {
+    uint8_t cfg = ACCEL_ACTIVE_MODE;
+    if (I2C_write(&i2c, ACCEL_CTRL_REG1, &cfg, 1) < 0) {
         perror("config");
         I2C_closeBus(&i2c);
         return -1;
@@ -207,16 +125,8 @@ Accel_open(void)
 void
 Accel_close(void)
 {
-    uint8_t CTRL_REG1;
-
-    if (ZEN_CAPE == 'r') {
-        CTRL_REG1 = 0x20;
-    } else if (ZEN_CAPE == 'g') {
-        CTRL_REG1 = 0x2A;
-    }
-
     uint8_t z = 0;
-    I2C_write(&i2c, CTRL_REG1, &z, 1);
+    I2C_write(&i2c, ACCEL_CTRL_REG1, &z, 1);
     I2C_closeBus(&i2c);
 }
 
@@ -225,39 +135,28 @@ Accel_read(Accel_Sample* out)
 {
     // Reading 6 bytes of data, but we need + 1 because on Zen Cape green, the
     // first byte is always 0xFF.
-    uint8_t buf[7];
+    uint8_t buf[ACCEL_NUM_BYTES_TO_READ];
 
-    // This variable is not terribly important to understand; it just happens
-    // to fall into a pattern that represents both capes accurately.
-    int indexAdjust;
-
-    if (ZEN_CAPE == 'r') {
-        if (I2C_read(&i2c, 0x28 + 0x80, buf, 6) < 0) {
-            return -1;
-        }
-        indexAdjust = 0;
-    } else if (ZEN_CAPE == 'g') {
-        if (I2C_read(&i2c, 0x01, buf, 7) < 0) {
-            return -1;
-        }
-        indexAdjust = 2;
+    if (I2C_read(&i2c, ACCEL_DATA_READ, buf, ACCEL_NUM_BYTES_TO_READ) < 0) {
+        return -1;
     }
 
-    // Parsing the register data is the same across both capes.
+    // INDEX_ADJUST is not terribly important to understand; it just happens
+    // to fall into a pattern that represents both capes accurately.
 
     /* Samples are given as 12-bit 2's complement numbers
      * left-aligned in a 16-bit field given as 2 bytes.
      *
      * We first put the two bytes together and right-align them */
-    out->x = (((buf[1] << 8) | buf[0 + indexAdjust]) >> 4);
+    out->x = (((buf[1] << 8) | buf[0 + ACCEL_INDEX_ADJUST]) >> 4);
     /* Then subtract 2^11 if the high bit is set. */
     out->x -= ((1 << 11) & out->x) << 1;
 
     /* And repeat for the other axes. */
-    out->y = ((buf[3] << 8) | buf[2 + indexAdjust]) >> 4;
+    out->y = ((buf[3] << 8) | buf[2 + ACCEL_INDEX_ADJUST]) >> 4;
     out->y -= ((1 << 11) & out->y) << 1;
 
-    out->z = ((buf[5] << 8) | buf[4 + indexAdjust]) >> 4;
+    out->z = ((buf[5] << 8) | buf[4 + ACCEL_INDEX_ADJUST]) >> 4;
     out->z -= ((1 << 11) & out->z) << 1;
     /* The Z register will always feel ~1G from normal gravity when it is on
      * the table. We make a crude correction for it. */

--- a/client/hal/src/segDisplay.c
+++ b/client/hal/src/segDisplay.c
@@ -1,0 +1,239 @@
+#include "hal/segDisplay.h"
+
+#define GPIO_DIR_LEFT "/sys/class/gpio/gpio61/value"
+#define GPIO_DIR_RIGHT "/sys/class/gpio/gpio44/value"
+
+#define SEGDISPLAY_SLEEP_ms 5
+
+// Decrease to get more blinks, increase to get less blinks.
+// From testing this module alone, 400 results in around ~5 sec between blinks.
+#define BLINK_THRESHOLD 200
+
+// Admin vars
+static I2C_BusHandle i2c;
+static Mood* mood;
+static pthread_t _segDisplayThread;
+
+static bool init = false;
+
+//////////////////////// Function Prototypes /////////////////////////////
+static void
+SegDisplay_turnOffDigits(void);
+
+static void
+SegDisplay_displayLeftPattern(uint8_t top, uint8_t bot);
+
+static void
+SegDisplay_displayRightPattern(uint8_t top, uint8_t bot);
+
+// Display a pattern on each digit by rapidly switching on and off between
+// turning on the left and right digit.
+static void
+SegDisplay_displayPattern(const uint8_t* pattern);
+
+// Threaded function that retrieves the current mood, and displays the
+// corresponding emotion. Threaded separate from app.c because we don't want
+// flicker to be caused by other app activities getting in the way of the
+// displaying.
+static void*
+_display(void* args);
+
+///////////////////// Prototype implementations ///////////////////////////
+
+static void
+SegDisplay_turnOffDigits(void)
+{
+    assert(init);
+
+    fileio_write(GPIO_DIR_LEFT, "0");
+    fileio_write(GPIO_DIR_RIGHT, "0");
+}
+
+static void
+SegDisplay_displayLeftPattern(uint8_t top, uint8_t bot)
+{
+    assert(init);
+
+    // Prepare the digit pattern
+    I2C_write(&i2c, SEGDISPLAY_OUTB_REG, &top, 1);
+    I2C_write(&i2c, SEGDISPLAY_OUTA_REG, &bot, 1);
+
+    // Turn on the GPIO pin corresponding to the left LED digit
+    fileio_write(GPIO_DIR_LEFT, "1");
+}
+
+static void
+SegDisplay_displayRightPattern(uint8_t top, uint8_t bot)
+{
+    assert(init);
+
+    // Prepare the digit pattern
+    I2C_write(&i2c, SEGDISPLAY_OUTB_REG, &top, 1);
+    I2C_write(&i2c, SEGDISPLAY_OUTA_REG, &bot, 1);
+
+    // Turn on the GPIO pin corresponding to the right LED digit
+    fileio_write(GPIO_DIR_RIGHT, "1");
+}
+
+// Display a pattern on each digit by rapidly switching on and off between
+// turning on the left and right digit.
+static void
+SegDisplay_displayPattern(const uint8_t* pattern)
+{
+    assert(init);
+
+    SegDisplay_turnOffDigits();
+
+    SegDisplay_displayLeftPattern(pattern[PATTERN_LEFT_TOP],
+                                  pattern[PATTERN_LEFT_BOT]);
+    Timeutils_sleepForMs(SEGDISPLAY_SLEEP_ms);
+
+    SegDisplay_turnOffDigits();
+
+    SegDisplay_displayRightPattern(pattern[PATTERN_RIGHT_TOP],
+                                   pattern[PATTERN_RIGHT_BOT]);
+    Timeutils_sleepForMs(SEGDISPLAY_SLEEP_ms);
+}
+
+static void*
+_display(void* args)
+{
+    (void)args;
+
+    while (true) {
+        mood = Singer_getMood();
+        SegDisplay_displayEmotion(mood->emotion);
+    }
+
+    return NULL;
+}
+
+//////////////////// External Functions //////////////////////////
+
+int
+SegDisplay_init(void)
+{
+    // Used to randomize the duration of blinking and opening eyes
+    srand(time(NULL));
+
+    // Open I2C BUS 1
+    if (I2C_openBus(I2C_BUS1, &i2c) < 0) {
+        perror("segDisplay open");
+        return -1;
+    }
+
+    // Select segDisplay
+    if (I2C_selectDevice(&i2c, SEGDISPLAY_I2C_ADDRESS) < 0) {
+        perror("segDisplay select device");
+        return -1;
+    }
+
+    // Set direction of both 8-bit ports on I2C GPIO extender to be outputs
+    uint8_t cfg = 0x00;
+    if (I2C_write(&i2c, SEGDISPLAY_DIRA_REG, &cfg, 1) < 0) {
+        perror("segDisplay config");
+        I2C_closeBus(&i2c);
+        return -1;
+    }
+    if (I2C_write(&i2c, SEGDISPLAY_DIRB_REG, &cfg, 1) < 0) {
+        perror("segDisplay config");
+        I2C_closeBus(&i2c);
+        return -1;
+    }
+
+    // Set direction of both GPIO pins to be outputs
+    fileio_write("/sys/class/gpio/gpio61/direction", "out");
+    fileio_write("/sys/class/gpio/gpio44/direction", "out");
+
+    init = true;
+
+    // Create the thread
+    int rc;
+    if ((rc = pthread_create(&_segDisplayThread, NULL, _display, NULL)) != 0) {
+        perror("segDisplay pthread_create");
+        exit(-1);
+    }
+
+    return 0;
+}
+
+void
+SegDisplay_shutdown(void)
+{
+    assert(init);
+
+    I2C_closeBus(&i2c);
+    SegDisplay_turnOffDigits();
+
+    init = false;
+}
+
+void
+SegDisplay_displayEmotion(Emotion emotion)
+{
+    const uint8_t* eyesPattern;
+    const uint8_t* blinkPattern;
+
+    // Set the digit patterns according to the mood.
+    switch (emotion) {
+        case EMOTION_HAPPY:
+            eyesPattern = EYES_HAPPY;
+            blinkPattern = BLINK_HAPPY;
+            break;
+        case EMOTION_SAD:
+            eyesPattern = EYES_SAD;
+            blinkPattern = BLINK_SAD;
+            break;
+        case EMOTION_ANGRY:
+            eyesPattern = EYES_ANGRY;
+            blinkPattern = BLINK_ANGRY;
+            break;
+        case EMOTION_OVERSTIMULATED:
+            eyesPattern = EYES_OVERSTIMULATED;
+            blinkPattern = BLINK_OVERSTIMULATED;
+            break;
+        case EMOTION_NEUTRAL:
+            eyesPattern = EYES_NEUTRAL;
+            blinkPattern = BLINK_NEUTRAL;
+            break;
+        case EMOTION_SINGING:
+            eyesPattern = EYES_SINGING;
+            blinkPattern = BLINK_SINGING;
+            break;
+        default:
+            break;
+    }
+
+    // Special case that doesn't fit well in the generalized approach, because
+    // of how dynamic and specific this pattern is
+    if (emotion == EMOTION_OVERSTIMULATED) {
+        SegDisplay_displayPattern(EYES_OVERSTIMULATED);
+        Timeutils_sleepForMs(100);
+        SegDisplay_displayPattern(BLINK_OVERSTIMULATED);
+        Timeutils_sleepForMs(100);
+        return;
+    }
+
+    // - assume each displayEmotion call takes ~15ms (5ms left + 5ms right +
+    // overhead).
+    // - we want to blink every 2-10s, which is ~6s on average.
+    // - 6s = 6000ms / 15ms = 400. we want to blink 1/400 displayEmotion calls.
+
+    // - implementing this with random % based chance instead of a time call
+    // because we don't want our eyes to be stuck displaying a mood in a timed
+    // while loop; the mood can change on a dime, and this approach allows that.
+    bool blinking = Utils_getRandomIntBtwn(0, BLINK_THRESHOLD);
+    if (blinking == 0) {
+        printf("Blink at: %lld\n", Timeutils_getTimeInMs());
+
+        // Blinks should last longer than the standard ~15ms, should they happen
+        // to occur. We randomize from 50 - 300ms.
+        int blinkDuration = Utils_getRandomIntBtwn(50, 300);
+        long long currTime = Timeutils_getTimeInMs();
+        while (currTime + blinkDuration > Timeutils_getTimeInMs()) {
+            SegDisplay_displayPattern(blinkPattern);
+        }
+    } else {
+        SegDisplay_displayPattern(eyesPattern);
+    }
+}


### PR DESCRIPTION
-segDisplay is its own separate thread instead of in the main app loop because we don't want other app activities to be interfering with the segDisplay (else flickering would probably occur, is my guess)

-config file is just #defines and constants to keep it simple; comment and uncomment as required